### PR TITLE
Move sizing restrictions up to prevent exception

### DIFF
--- a/lib/src/dialogs/flutter_rounded_date_picker_dialog.dart
+++ b/lib/src/dialogs/flutter_rounded_date_picker_dialog.dart
@@ -254,6 +254,7 @@ class _FlutterRoundedDatePickerDialogState extends State<FlutterRoundedDatePicke
         switch (orientation) {
           case Orientation.portrait:
             return Container(
+              height: widget.height,
               decoration: BoxDecoration(
                 color: backgroundPicker,
                 borderRadius: BorderRadius.circular(widget.borderRadius),
@@ -263,13 +264,7 @@ class _FlutterRoundedDatePickerDialogState extends State<FlutterRoundedDatePicke
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: <Widget>[
                   header,
-                  if (widget.height == null)
-                    Flexible(child: picker)
-                  else
-                    SizedBox(
-                      height: widget.height,
-                      child: picker,
-                    ),
+                  Expanded(child: picker),
                   actions,
                 ],
               ),


### PR DESCRIPTION
if the height is set and overflows the screen size (minus keyboard inset etc), we get an exception otherwise

! the height property now includes the header and actions !