### PR TITLE
Add onMonthChange to FlutterRoundedDatePickerDialog

### DIFF
--- a/lib/src/dialogs/flutter_rounded_date_picker_dialog.dart
+++ b/lib/src/dialogs/flutter_rounded_date_picker_dialog.dart
@@ -34,7 +34,8 @@ class FlutterRoundedDatePickerDialog extends StatefulWidget {
       this.customWeekDays,
       this.builderDay,
       this.listDateDisabled,
-      this.onTapDay})
+      this.onTapDay,
+      this.onMonthChange})
       : super(key: key);
 
   final DateTime initialDate;
@@ -79,11 +80,15 @@ class FlutterRoundedDatePickerDialog extends StatefulWidget {
   final List<DateTime>? listDateDisabled;
   final OnTapDay? onTapDay;
 
+  final ValueSetter<DateTime>? onMonthChange;
+
   @override
-  _FlutterRoundedDatePickerDialogState createState() => _FlutterRoundedDatePickerDialogState();
+  _FlutterRoundedDatePickerDialogState createState() =>
+      _FlutterRoundedDatePickerDialogState();
 }
 
-class _FlutterRoundedDatePickerDialogState extends State<FlutterRoundedDatePickerDialog> {
+class _FlutterRoundedDatePickerDialogState
+    extends State<FlutterRoundedDatePickerDialog> {
   @override
   void initState() {
     super.initState();
@@ -152,6 +157,8 @@ class _FlutterRoundedDatePickerDialogState extends State<FlutterRoundedDatePicke
     }
     if (value == _selectedDate) return;
 
+    if (widget.onMonthChange != null) widget.onMonthChange!(value);
+
     _vibrate();
     setState(() {
       _mode = DatePickerMode.day;
@@ -190,22 +197,22 @@ class _FlutterRoundedDatePickerDialogState extends State<FlutterRoundedDatePicke
       case DatePickerMode.day:
       default:
         return FlutterRoundedMonthPicker(
-          key: _pickerKey,
-          selectedDate: _selectedDate,
-          onChanged: _handleDayChanged,
-          firstDate: widget.firstDate,
-          lastDate: widget.lastDate,
-          era: widget.era,
-          locale: widget.locale,
-          selectableDayPredicate: widget.selectableDayPredicate,
-          fontFamily: widget.fontFamily,
-          style: widget.styleDatePicker,
-          borderRadius: widget.borderRadius,
-          customWeekDays: widget.customWeekDays,
-          builderDay: widget.builderDay,
-          listDateDisabled: widget.listDateDisabled,
-          onTapDay: widget.onTapDay,
-        );
+            key: _pickerKey,
+            selectedDate: _selectedDate,
+            onChanged: _handleDayChanged,
+            firstDate: widget.firstDate,
+            lastDate: widget.lastDate,
+            era: widget.era,
+            locale: widget.locale,
+            selectableDayPredicate: widget.selectableDayPredicate,
+            fontFamily: widget.fontFamily,
+            style: widget.styleDatePicker,
+            borderRadius: widget.borderRadius,
+            customWeekDays: widget.customWeekDays,
+            builderDay: widget.builderDay,
+            listDateDisabled: widget.listDateDisabled,
+            onTapDay: widget.onTapDay,
+            onMonthChange: widget.onMonthChange);
     }
   }
 
@@ -232,13 +239,16 @@ class _FlutterRoundedDatePickerDialogState extends State<FlutterRoundedDatePicke
 
     Color backgroundPicker = theme.dialogBackgroundColor;
     if (_mode == DatePickerMode.day) {
-      backgroundPicker = widget.styleDatePicker?.backgroundPicker ?? theme.dialogBackgroundColor;
+      backgroundPicker = widget.styleDatePicker?.backgroundPicker ??
+          theme.dialogBackgroundColor;
     } else {
-      backgroundPicker = widget.styleYearPicker?.backgroundPicker ?? theme.dialogBackgroundColor;
+      backgroundPicker = widget.styleYearPicker?.backgroundPicker ??
+          theme.dialogBackgroundColor;
     }
 
     final Dialog dialog = Dialog(
-      child: OrientationBuilder(builder: (BuildContext context, Orientation orientation) {
+      child: OrientationBuilder(
+          builder: (BuildContext context, Orientation orientation) {
         final Widget header = FlutterRoundedDatePickerHeader(
             selectedDate: _selectedDate,
             mode: _mode,

--- a/lib/src/dialogs/flutter_rounded_date_picker_dialog.dart
+++ b/lib/src/dialogs/flutter_rounded_date_picker_dialog.dart
@@ -80,7 +80,7 @@ class FlutterRoundedDatePickerDialog extends StatefulWidget {
   final List<DateTime>? listDateDisabled;
   final OnTapDay? onTapDay;
 
-  final ValueSetter<DateTime>? onMonthChange;
+  final Function? onMonthChange;
 
   @override
   _FlutterRoundedDatePickerDialogState createState() =>
@@ -149,7 +149,7 @@ class _FlutterRoundedDatePickerDialogState
     });
   }
 
-  void _handleYearChanged(DateTime value) {
+  Future<void> _handleYearChanged(DateTime value) async {
     if (value.isBefore(widget.firstDate)) {
       value = widget.firstDate;
     } else if (value.isAfter(widget.lastDate)) {
@@ -157,7 +157,7 @@ class _FlutterRoundedDatePickerDialogState
     }
     if (value == _selectedDate) return;
 
-    if (widget.onMonthChange != null) widget.onMonthChange!(value);
+    if (widget.onMonthChange != null) await widget.onMonthChange!(value);
 
     _vibrate();
     setState(() {
@@ -187,7 +187,7 @@ class _FlutterRoundedDatePickerDialogState
         return FlutterRoundedYearPicker(
           key: _pickerKey,
           selectedDate: _selectedDate,
-          onChanged: _handleYearChanged,
+          onChanged: (DateTime date) async => await _handleYearChanged(date),
           firstDate: widget.firstDate,
           lastDate: widget.lastDate,
           era: widget.era,

--- a/lib/src/flutter_rounded_date_picker_widget.dart
+++ b/lib/src/flutter_rounded_date_picker_widget.dart
@@ -118,7 +118,7 @@ Future<DateTime?> showRoundedDatePicker(
     BuilderDayOfDatePicker? builderDay,
     List<DateTime>? listDateDisabled,
     OnTapDay? onTapDay,
-    ValueSetter<DateTime>? onMonthChange}) async {
+    Function? onMonthChange}) async {
   initialDate ??= DateTime.now();
   firstDate ??= DateTime(initialDate.year - 1);
   lastDate ??= DateTime(initialDate.year + 1);

--- a/lib/src/flutter_rounded_date_picker_widget.dart
+++ b/lib/src/flutter_rounded_date_picker_widget.dart
@@ -117,7 +117,8 @@ Future<DateTime?> showRoundedDatePicker(
     List<String>? customWeekDays,
     BuilderDayOfDatePicker? builderDay,
     List<DateTime>? listDateDisabled,
-    OnTapDay? onTapDay}) async {
+    OnTapDay? onTapDay,
+    ValueSetter<DateTime>? onMonthChange}) async {
   initialDate ??= DateTime.now();
   firstDate ??= DateTime(initialDate.year - 1);
   lastDate ??= DateTime(initialDate.year + 1);
@@ -140,7 +141,8 @@ Future<DateTime?> showRoundedDatePicker(
     'Provided initialDate must satisfy provided selectableDayPredicate',
   );
   assert(
-    (onTapActionButton != null && textActionButton != null) || onTapActionButton == null,
+    (onTapActionButton != null && textActionButton != null) ||
+        onTapActionButton == null,
     "If you provide onLeftBtn, you must provide leftBtn",
   );
   assert(debugCheckHasMaterialLocalizations(context));
@@ -180,6 +182,7 @@ Future<DateTime?> showRoundedDatePicker(
           builderDay: builderDay,
           listDateDisabled: listDateDisabled,
           onTapDay: onTapDay,
+          onMonthChange: onMonthChange,
         ),
       ),
     ),

--- a/lib/src/widgets/flutter_rounded_month_picker.dart
+++ b/lib/src/widgets/flutter_rounded_month_picker.dart
@@ -46,7 +46,8 @@ class FlutterRoundedMonthPicker extends StatefulWidget {
       this.customWeekDays,
       this.builderDay,
       this.listDateDisabled,
-      this.onTapDay})
+      this.onTapDay,
+      this.onMonthChange})
       : assert(!firstDate.isAfter(lastDate)),
 //        assert(selectedDate.isAfter(firstDate) || selectedDate.isAtSameMomentAs(firstDate)),
         super(key: key);
@@ -91,13 +92,18 @@ class FlutterRoundedMonthPicker extends StatefulWidget {
   final List<DateTime>? listDateDisabled;
   final OnTapDay? onTapDay;
 
+  final ValueSetter<DateTime>? onMonthChange;
+
   @override
-  _FlutterRoundedMonthPickerState createState() => _FlutterRoundedMonthPickerState();
+  _FlutterRoundedMonthPickerState createState() =>
+      _FlutterRoundedMonthPickerState();
 }
 
-class _FlutterRoundedMonthPickerState extends State<FlutterRoundedMonthPicker> with SingleTickerProviderStateMixin {
+class _FlutterRoundedMonthPickerState extends State<FlutterRoundedMonthPicker>
+    with SingleTickerProviderStateMixin {
   static final Animatable<double> _chevronOpacityTween =
-      Tween<double>(begin: 1.0, end: 0.0).chain(CurveTween(curve: Curves.easeInOut));
+      Tween<double>(begin: 1.0, end: 0.0)
+          .chain(CurveTween(curve: Curves.easeInOut));
 
   @override
   void initState() {
@@ -147,7 +153,8 @@ class _FlutterRoundedMonthPickerState extends State<FlutterRoundedMonthPicker> w
 
   void _updateCurrentDate() {
     _todayDate = DateTime.now();
-    final DateTime tomorrow = DateTime(_todayDate.year, _todayDate.month, _todayDate.day + 1);
+    final DateTime tomorrow =
+        DateTime(_todayDate.year, _todayDate.month, _todayDate.day + 1);
     Duration timeUntilTomorrow = tomorrow.difference(_todayDate);
     // so we don't miss it by rounding
     timeUntilTomorrow += const Duration(seconds: 1);
@@ -158,7 +165,9 @@ class _FlutterRoundedMonthPickerState extends State<FlutterRoundedMonthPicker> w
   }
 
   static int _monthDelta(DateTime startDate, DateTime endDate) {
-    return (endDate.year - startDate.year) * 12 + endDate.month - startDate.month;
+    return (endDate.year - startDate.year) * 12 +
+        endDate.month -
+        startDate.month;
   }
 
   /// Add months to a month truncated date.
@@ -203,6 +212,7 @@ class _FlutterRoundedMonthPickerState extends State<FlutterRoundedMonthPicker> w
         duration: _kMonthScrollDuration,
         curve: Curves.ease,
       );
+      if (widget.onMonthChange != null) widget.onMonthChange!(_nextMonthDate);
     }
   }
 
@@ -216,6 +226,8 @@ class _FlutterRoundedMonthPickerState extends State<FlutterRoundedMonthPicker> w
         duration: _kMonthScrollDuration,
         curve: Curves.ease,
       );
+      if (widget.onMonthChange != null)
+        widget.onMonthChange!(_previousMonthDate);
     }
   }
 
@@ -257,7 +269,8 @@ class _FlutterRoundedMonthPickerState extends State<FlutterRoundedMonthPicker> w
       decoration: BoxDecoration(
           color: widget.style?.backgroundPicker,
           borderRadius: orientation == Orientation.landscape
-              ? BorderRadius.only(topRight: Radius.circular(widget.borderRadius))
+              ? BorderRadius.only(
+                  topRight: Radius.circular(widget.borderRadius))
               : null),
       // The month picker just adds month navigation to the day picker, so make
       // it the same height as the DayPicker
@@ -306,7 +319,9 @@ class _FlutterRoundedMonthPickerState extends State<FlutterRoundedMonthPicker> w
                   tooltip: _isDisplayingFirstMonth
                       ? null
                       : '${localizations.previousMonthTooltip} ${localizations.formatMonthYear(_previousMonthDate)}',
-                  onPressed: _isDisplayingFirstMonth == true ? null : _handlePreviousMonth,
+                  onPressed: _isDisplayingFirstMonth == true
+                      ? null
+                      : _handlePreviousMonth,
                 ),
               ),
             ),

--- a/lib/src/widgets/flutter_rounded_year_picker.dart
+++ b/lib/src/widgets/flutter_rounded_year_picker.dart
@@ -43,7 +43,7 @@ class FlutterRoundedYearPicker extends StatefulWidget {
   final DateTime selectedDate;
 
   /// Called when the user picks a year.
-  final ValueChanged<DateTime> onChanged;
+  final Function onChanged;
 
   /// The earliest date the user is permitted to pick.
   final DateTime firstDate;
@@ -64,7 +64,8 @@ class FlutterRoundedYearPicker extends StatefulWidget {
   final MaterialRoundedYearPickerStyle? style;
 
   @override
-  _FlutterRoundedYearPickerState createState() => _FlutterRoundedYearPickerState();
+  _FlutterRoundedYearPickerState createState() =>
+      _FlutterRoundedYearPickerState();
 }
 
 class _FlutterRoundedYearPickerState extends State<FlutterRoundedYearPicker> {
@@ -77,7 +78,8 @@ class _FlutterRoundedYearPickerState extends State<FlutterRoundedYearPicker> {
     _itemExtent = widget.style?.heightYearRow ?? 50;
     scrollController = ScrollController(
       // Move the initial scroll position to the currently selected date's year.
-      initialScrollOffset: (widget.selectedDate.year - widget.firstDate.year) * _itemExtent,
+      initialScrollOffset:
+          (widget.selectedDate.year - widget.firstDate.year) * _itemExtent,
     );
   }
 


### PR DESCRIPTION
Pass a function that runs on a month change. This way can load data for whatever month is currently displayed. It is only added on the dialog, but can obviously be added to the widget as well if there is an interest for it.