### PR TITLE
Fix bugs in month header

### DIFF
--- a/lib/src/widgets/flutter_rounded_day_picker.dart
+++ b/lib/src/widgets/flutter_rounded_day_picker.dart
@@ -423,7 +423,6 @@ class FlutterRoundedDayPicker extends StatelessWidget {
       child: Column(
         children: <Widget>[
           Container(
-            height: 45,
             decoration: BoxDecoration(
                 color: style?.backgroundHeaderMonth,
                 borderRadius: orientation == Orientation.landscape

--- a/lib/src/widgets/flutter_rounded_month_picker.dart
+++ b/lib/src/widgets/flutter_rounded_month_picker.dart
@@ -315,7 +315,7 @@ class _FlutterRoundedMonthPickerState extends State<FlutterRoundedMonthPicker>
 
           /// Arrow Left
           PositionedDirectional(
-            top: widget.style?.marginLeftArrowPrevious ?? 0.0,
+            top: widget.style?.marginTopArrowPrevious ?? 0.0,
             start: widget.style?.marginLeftArrowPrevious ?? 8.0,
             child: Semantics(
               sortKey: _MonthPickerSortKey.previousMonth,


### PR DESCRIPTION
Couple of bugs that I have noticed

- Remove fixed height in month header, this may break your example since it was added https://github.com/benznest/flutter_rounded_date_picker/commit/d43fee10821bbdc7adc0031baf7800894479341b
- Previous month arrow was using the wrong padding variable